### PR TITLE
Not showing empty tags in sitemap

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -30,6 +30,12 @@ var path = require('path'),
                 }).updated.toDate();
                 return item;
             },
+            filterEmptyTags = function (tag) {
+                if (!tag.posts || tag.posts.length === 0) {
+                    return false;
+                }
+                return true;
+            },
 
             lastUpdatedPost,
             lastUpdatedPage,
@@ -112,6 +118,7 @@ var path = require('path'),
                 }
                 var tags = _(locals.tags.toArray())
                     .map(setItemLastUpdate)
+                    .filter(filterEmptyTags)
                     .sortByOrder('updated')
                     .value();
 

--- a/test/allSitemaps.js
+++ b/test/allSitemaps.js
@@ -17,6 +17,7 @@
         hexo = new Hexo(__dirname, {silent: true}),
         Post = hexo.model('Post'),
         Page = hexo.model('Page'),
+        Tag  = hexo.model('Tag'),
         generator = require(path.join(__dirname, '../lib/generator')).bind(hexo),
         posts = [
             {source: 'foo', slug: 'foo', path: 'foo', updated: moment.utc([2015, 0, 1, 8]).toDate()},
@@ -27,6 +28,9 @@
             {source: 'Page 1', slug: 'Page 1', updated: moment.utc([2014, 11, 10, 9]).toDate(), path: 'page1'},
             {source: 'Page 2', slug: 'Page 2', updated: moment.utc([2014, 11, 15, 10]).toDate(), path: 'page2'},
             {source: 'Page 3', slug: 'Page 3', updated: moment.utc([2014, 11, 20, 11]).toDate(), path: 'page3'}
+        ],
+        tags = [
+            {name: 'footag', path: 'footag'}
         ],
         locals,
 
@@ -63,6 +67,10 @@
             return Page.insert(pages);
         },
 
+        insertTags = function () {
+            console.log('insertTags');
+            return Tag.insert(tags);
+        },
         setHexoLocals = function () {
             console.log('setHexoLocals');
             locals = hexo.locals.toObject();
@@ -74,6 +82,7 @@
         before(function () {
             return insertPosts()
                 .then(insertPages)
+                .then(insertTags)
                 .then(setHexoLocals);
         });
 

--- a/test/expected/full-tag-sitemap.xml
+++ b/test/expected/full-tag-sitemap.xml
@@ -2,20 +2,6 @@
 <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     
     <url>
-        <loc>http://yoursite.com/tags/Tag1/</loc>
-        <lastmod>2015-01-01T08:00:00.000Z</lastmod>
-        <changefreq>weekly</changefreq>
-        <priority>0.2</priority>
-    </url>
-    
-    <url>
-        <loc>http://yoursite.com/tags/Tag2/</loc>
-        <lastmod>2015-01-01T08:00:00.000Z</lastmod>
-        <changefreq>weekly</changefreq>
-        <priority>0.2</priority>
-    </url>
-    
-    <url>
         <loc>http://yoursite.com/tags/Tag3/</loc>
         <lastmod>2015-01-01T08:00:00.000Z</lastmod>
         <changefreq>weekly</changefreq>


### PR DESCRIPTION
By default this plugin shows every tag found in hexo. I have many tags mentioned only in drafts folder, so 404 links to tags do exist in my published sitemap.xml.

This PR fixes it.