### PR TITLE
Added option flag for generating tag or category

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ sitemap:
     path: sitemap.xml
 ```
 
+You can exclude tag or category page from the sitemap by adding `tag: false` or `category: false` under the `sitemap` configuration.
+
+``` yaml
+sitemap:
+    path: sitemap.xml
+    tag: false
+    category: false
+```
+
 - **path** - Index sitemap path.
 
 ## Excluding pages or posts

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,1 @@
+build: off

--- a/lib/category.js
+++ b/lib/category.js
@@ -7,8 +7,11 @@ var mentionedInPosts = function (category) {
   return (category.posts.length > 0);
 };
 
-var category = function (locals) {
+var category = function (locals, config) {
   var get = function () {
+    if (config.sitemap && config.sitemap.category === false) {
+      return;
+    }
     if (locals.categories.length === 0) {
       return;
     }

--- a/lib/category.js
+++ b/lib/category.js
@@ -9,9 +9,9 @@ var mentionedInPosts = function (category) {
 
 var category = function (locals, config) {
   var get = function () {
-    if (config.sitemap && config.sitemap.category === false) {
-      return;
-    }
+    // if (config && config.sitemap && config.sitemap.category === false) {
+    //   return;
+    // }
     if (locals.categories.length === 0) {
       return;
     }

--- a/lib/category.js
+++ b/lib/category.js
@@ -9,12 +9,13 @@ var mentionedInPosts = function (category) {
 
 var category = function (locals, config) {
   var get = function () {
-    // if (config && config.sitemap && config.sitemap.category === false) {
-    //   return;
-    // }
+    if (config.sitemap && config.sitemap.category === false) {
+      return;
+    }
     if (locals.categories.length === 0) {
       return;
     }
+
     var categories = _(locals.categories.toArray())
       .filter(mentionedInPosts)
       .map(common.setItemLastUpdate)

--- a/lib/tag.js
+++ b/lib/tag.js
@@ -7,8 +7,11 @@ var mentionedInPosts = function (tag) {
   return (tag.posts.length > 0);
 };
 
-var tag = function (locals) {
+var tag = function (locals, config) {
   var get = function () {
+    if (config.sitemap && config.sitemap.tag === false) {
+      return;
+    }
     if (locals.tags.length === 0) {
       return;
     }

--- a/lib/tag.js
+++ b/lib/tag.js
@@ -9,7 +9,7 @@ var mentionedInPosts = function (tag) {
 
 var tag = function (locals, config) {
   var get = function () {
-    if (config.sitemap && config.sitemap.tag === false) {
+    if (config && config.sitemap && config.sitemap.tag === false) {
       return;
     }
     if (locals.tags.length === 0) {

--- a/lib/tag.js
+++ b/lib/tag.js
@@ -9,12 +9,13 @@ var mentionedInPosts = function (tag) {
 
 var tag = function (locals, config) {
   var get = function () {
-    if (config && config.sitemap && config.sitemap.tag === false) {
+    if (config.sitemap && config.sitemap.tag === false) {
       return;
     }
     if (locals.tags.length === 0) {
       return;
     }
+
     var tags = _(locals.tags.toArray())
       .filter(mentionedInPosts)
       .map(common.setItemLastUpdate)

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "grunt-lineending": "0.2.4",
     "grunt-mocha-cli": "2.0.0",
     "grunt-mocha-istanbul": "3.0.1",
-    "grunt-nice-package": "0.10.2",
+    "grunt-nice-package": "^0.10.4",
     "hexo": "^3.2.0",
     "istanbul": "0.4.2",
     "jshint-stylish": "2.1.0",

--- a/test/category.js
+++ b/test/category.js
@@ -8,11 +8,14 @@ var Hexo = require('hexo'),
   assert = chai.assert,
   category = require('../lib/category');
 
-var instanciateHexo = function () {
+var instanciateHexo = function (category) {
   var hexo = new Hexo(__dirname, {silent: true});
   hexo.config.sitemap = {
     path: 'sitemap.xml'
   };
+  if (category !== undefined) {
+    hexo.config.sitemap.category = category;
+  }
   hexo.config.permalink = ':title';
   hexo.init();
   return Promise.resolve(hexo);
@@ -64,6 +67,20 @@ describe('SEO-friendly sitemap generator', function () {
     };
 
     return instanciateHexo()
+      .then(insertPosts)
+      .spread(setPostCategory)
+      .spread(getHexoLocalsAndConfig)
+      .then(applyCategory)
+      .call('get')
+      .then(checkAssertions);
+  });
+
+  it('should not generate sitemap category file if config.sitemap.category set to false', function () {
+    var checkAssertions = function (result) {
+      assert.isUndefined(result);
+    };
+
+    return instanciateHexo(false)
       .then(insertPosts)
       .spread(setPostCategory)
       .spread(getHexoLocalsAndConfig)

--- a/test/category.js
+++ b/test/category.js
@@ -33,19 +33,23 @@ var setPostCategory = function (hexo, posts) {
   return [hexo, post.setCategories(['Category1'])];
 };
 
-var getHexoLocals = function (hexo) {
-  return Promise.resolve(hexo.locals.toObject());
+var getHexoLocalsAndConfig = function (hexo) {
+  return Promise.resolve([hexo.locals.toObject(), hexo.config]);
 };
 
 describe('SEO-friendly sitemap generator', function () {
+  var applyCategory = function (args) {
+    return category.apply(null, args);
+  };
+
   it('should not generate sitemap category file if no categories are mentioned in posts', function () {
     var checkAssertions = function (result) {
       assert.isUndefined(result);
     };
 
     return instanciateHexo()
-      .then(getHexoLocals)
-      .then(category)
+      .then(getHexoLocalsAndConfig)
+      .then(applyCategory)
       .call('get')
       .then(checkAssertions);
   });
@@ -62,8 +66,8 @@ describe('SEO-friendly sitemap generator', function () {
     return instanciateHexo()
       .then(insertPosts)
       .spread(setPostCategory)
-      .spread(getHexoLocals)
-      .then(category)
+      .spread(getHexoLocalsAndConfig)
+      .then(applyCategory)
       .call('get')
       .then(checkAssertions);
   });

--- a/test/tag.js
+++ b/test/tag.js
@@ -33,19 +33,23 @@ var setPostTag = function (hexo, posts) {
   return [hexo, post.setTags(['Tag1'])];
 };
 
-var getHexoLocals = function (hexo) {
-  return Promise.resolve(hexo.locals.toObject());
+var getHexoLocalsAndConfig = function (hexo) {
+  return Promise.resolve([hexo.locals.toObject(), hexo.config]);
 };
 
 describe('SEO-friendly sitemap generator', function () {
+  var applyTag = function (args) {
+    return tag.apply(null, args);
+  };
+
   it('should not generate sitemap tag file if no tags are mentioned in posts', function () {
     var checkAssertions = function (result) {
       assert.isUndefined(result);
     };
 
     return instanciateHexo()
-      .then(getHexoLocals)
-      .then(tag)
+      .then(getHexoLocalsAndConfig)
+      .then(applyTag)
       .call('get')
       .then(checkAssertions);
   });
@@ -62,8 +66,8 @@ describe('SEO-friendly sitemap generator', function () {
     return instanciateHexo()
       .then(insertPosts)
       .spread(setPostTag)
-      .spread(getHexoLocals)
-      .then(tag)
+      .spread(getHexoLocalsAndConfig)
+      .then(applyTag)
       .call('get')
       .then(checkAssertions);
   });

--- a/test/tag.js
+++ b/test/tag.js
@@ -8,11 +8,14 @@ var Hexo = require('hexo'),
   assert = chai.assert,
   tag = require('../lib/tag');
 
-var instanciateHexo = function () {
+var instanciateHexo = function (tag) {
   var hexo = new Hexo(__dirname, {silent: true});
   hexo.config.sitemap = {
     path: 'sitemap.xml'
   };
+  if (tag !== undefined) {
+    hexo.config.sitemap.tag = tag;
+  }
   hexo.config.permalink = ':title';
   hexo.init();
   return Promise.resolve(hexo);
@@ -64,6 +67,20 @@ describe('SEO-friendly sitemap generator', function () {
     };
 
     return instanciateHexo()
+      .then(insertPosts)
+      .spread(setPostTag)
+      .spread(getHexoLocalsAndConfig)
+      .then(applyTag)
+      .call('get')
+      .then(checkAssertions);
+  });
+
+  it('should not generate sitemap tag file if config.sitemap.tag set to false', function () {
+    var checkAssertions = function (result) {
+      assert.isUndefined(result);
+    };
+
+    return instanciateHexo(false)
       .then(insertPosts)
       .spread(setPostTag)
       .spread(getHexoLocalsAndConfig)


### PR DESCRIPTION
For those who want to exclude tag or category from sitemap, these options will be helpful.

I should have updated the tests together, however, I couldn't due to some errors (fatal: repository 'https://github.com/hemanth/package.json-validator.git/' not found). I manually tested the changes with my blog. If you fix the dependency issue, I will update the test, too.