### PR TITLE
fix wrong tag url in sitemap

### DIFF
--- a/views/tag-sitemap.ejs
+++ b/views/tag-sitemap.ejs
@@ -3,7 +3,7 @@
 <% include encodeURLAndEscape.ejs %>
 <% data.items.forEach(function(tag){ %>
     <url>
-        <loc><%- encodeURLAndEscape(tag.permalink) %></loc>
+        <loc><%- tag.permalink %></loc>
         <lastmod><%= tag.updated.toISOString() %></lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.2</priority>


### PR DESCRIPTION
My site always generate wrong tag urls when using this plugin, so I just dived into it for details. I find that this plugin always encode Chinese characters twice so that urls with Chinese characters can't be visited right. I guess the tag.permalink would result encoded link so that the function of encodedURLAndEscape just works the wrong way.

Here's my sites' package version:
hexo: 4.2.1
hexo-cli: 3.1.0
os: Darwin 19.6.0 darwin x64
node: 14.5.0

P.S. I only changed the tag because I didn't know whether others are use the same way.

Thanks.