### PR TITLE
fix category path

### DIFF
--- a/views/category-sitemap.ejs
+++ b/views/category-sitemap.ejs
@@ -4,7 +4,7 @@
 <% include root-page.ejs %>
 <% data.items.forEach(function(category){ %>
     <url>
-        <loc><%- encodeURLAndEscape(category.permalink) %></loc>
+        <loc><%- category.permalink %></loc>
         <lastmod><%= category.updated.toISOString() %></lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.2</priority>


### PR DESCRIPTION
Just like https://github.com/ludoviclefevre/hexo-generator-seo-friendly-sitemap/commit/655f5dd78b02f9b8c66273dd5ced86e296218e1b

For the wrong path, see: https://bdded8d7.blog-ci.pages.dev/category-sitemap.xml